### PR TITLE
Adds examples of how to parameterise fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,16 @@ repos:
         types: [python]
         additional_dependencies: ["click==8.0.4"]
 
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.6.0
+    hooks:
+      - id: numpydoc-validation
+        exclude: |
+          (?x)(
+              tests/|
+              docs/
+          )
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pytest Examples
 
-[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json))](https://github.com/astral-sh/ruff)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code style: flake8](https://img.shields.io/badge/code%20style-flake8-456789.svg)](https://github.com/psf/flake8)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "pytest-examples"
 description = "Examples of working with pytest"
 readme = "README.md"
-license = {text = "GNU Lesser GPLv3 only"}
+license = {text = "MIT"}
 dynamic = ["version"]
 authors = [
   {name = "Neil Shephard", email = "n.shephard@sheffield.ac.uk"},
@@ -32,6 +32,8 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
   "loguru",
+  "numpy",
+  "scikit-image",
 ]
 
 [project.optional-dependencies]
@@ -41,7 +43,6 @@ tests = [
   "pytest-cov",
   "pytest-lazy-fixture",
   "pytest-tmp-files",
-  "filetype",
 ]
 docs = [
   "Sphinx",
@@ -79,8 +80,8 @@ pypi = [
 ]
 
 [project.urls]
-Source = "https://github.com/ns-rse/pytest-example"
-Bug_Tracker = "https://github.com/ns-rse/pytest-example/issues"
+Source = "https://github.com/ns-rse/pytest-examples"
+Bug_Tracker = "https://github.com/ns-rse/pytest-examples/issues"
 
 [tool.flake8]
 max_line_length=120

--- a/pytest_examples/shapes.py
+++ b/pytest_examples/shapes.py
@@ -1,0 +1,20 @@
+"""Summarise Shapes."""
+import numpy.typing as npt
+from skimage import measure
+
+
+def summarise_shape(shape: npt.NDArray) -> list:
+    """
+    Summarise the region properties of a 2D numpy array using Scikit-Image.
+
+    Parameters
+    ----------
+    shape : npt.NDArray
+        2D binary array of a shape.
+
+    Returns
+    -------
+    list
+        List of Region Properties each item describing one labelled region.
+    """
+    return measure.regionprops(shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Fixtures for tests."""
+import numpy as np
+import numpy.typing as npt
+import pytest
+from skimage import draw
+
+
+@pytest.fixture()
+def square() -> npt.NDArray:
+    """Return a 2D numpy array of a square."""
+    square_array = np.zeros((6, 6), dtype=np.uint8)
+    start = (1, 1)
+    end = (5, 5)
+    rr, cc = draw.rectangle_perimeter(start, end, shape=square_array.shape)
+    square_array[rr, cc] = 1
+    return square_array
+
+
+@pytest.fixture()
+def circle() -> npt.NDArray:
+    """Return a 2D numpy array of a circle."""
+    circle_array = np.zeros((7, 7), dtype=np.uint8)
+    rr, cc = draw.circle_perimeter(r=4, c=4, radius=2, shape=circle_array.shape)
+    circle_array[rr, cc] = 1
+    return circle_array

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -4,6 +4,11 @@ import pytest
 from pytest_examples.divide import divide
 
 
+def test_divide_unparameterised() -> None:
+    """Test the divide function."""
+    assert divide(10, 5) == 2
+
+
 @pytest.mark.parametrize(
     ("a", "b", "expected"),
     [

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,0 +1,43 @@
+"""Test the shapes module."""
+import pytest
+
+from pytest_examples.shapes import summarise_shape
+
+
+@pytest.mark.parametrize(
+    ("shape", "area", "feret_diameter_max", "centroid"),
+    [
+        pytest.param("square", 11, 7.810249675906654, (1.3636363636363635, 1.3636363636363635), id="summary of square"),
+        pytest.param("circle", 12, 5.385164807134504, (4, 4), id="summary of circle"),
+    ],
+)
+def test_summarise_shape_get_fixture_value(
+    shape: str, area: float, feret_diameter_max: float, centroid: tuple, request
+) -> None:
+    """Test the summarisation of shapes."""
+    shape_summary = summarise_shape(request.getfixturevalue(shape))
+    assert shape_summary[0]["area"] == area
+    assert shape_summary[0]["feret_diameter_max"] == feret_diameter_max
+    assert shape_summary[0]["centroid"] == centroid
+
+
+@pytest.mark.parametrize(
+    ("shape", "area", "feret_diameter_max", "centroid"),
+    [
+        pytest.param(
+            pytest.lazy_fixture("square"),
+            11,
+            7.810249675906654,
+            (1.3636363636363635, 1.3636363636363635),
+            id="summary of square",
+        ),
+        pytest.param(pytest.lazy_fixture("circle"), 12, 5.385164807134504, (4, 4), id="summary of circle"),
+    ],
+)
+def test_summarise_shape_lazy_fixture(shape: str, area: float, feret_diameter_max: float, centroid: tuple) -> None:
+    """Test the summarisation of shapes."""
+    shape_summary = summarise_shape(shape)
+    print(f"{shape_summary[0]['centroid']=}")
+    assert shape_summary[0]["area"] == area
+    assert shape_summary[0]["feret_diameter_max"] == feret_diameter_max
+    assert shape_summary[0]["centroid"] == centroid


### PR DESCRIPTION
Shows two ways of adding parameterised fixtures to tests.

Also...

+ Adds pre-commit hook for [numpydoc](https://github.com/numpy/numpydoc).
+ Corrects license reference in `pyproject.toml` to MIT.
+ Corrects `project.urls` in `pyproject.toml`.
+ Adds a basic unparameterised test to `tests/test_divide.py`.