### PR TITLE
Adds mypy to pre-commit and corrects typehints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,11 @@ repos:
               docs/
           )
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+    -   id: mypy
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,4 +66,4 @@ ci:
   autofix_commit_msg: '[pre-commit.ci] Fixing issues with pre-commit'
   autoupdate_schedule: monthly
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit-autoupdate'
-  skip: [] # Optionally list ids of hooks to skip on CI
+  skip: [pylint] # Optionally list ids of hooks to skip on CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ tests = [
   "pytest",
   "pytest-cov",
   "pytest-lazy-fixture",
+  "pytest-mpl",
   "pytest-tmp-files",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,10 @@ python_version = 3.11
 strict = true
 show_error_codes = true
 warn_unreachable = true
+disable_error_code = [
+  "misc",  # Due to errors "Untyped decorator makes function 'x' untyped" from pytest
+  "no-any-return"
+]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 exclude='''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ write_to = "_version.py"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = ["--cov", "--mpl", "-ra", "--showlocals", "--strict-config", "--strict-markers"]
+addopts = ["--cov", "-ra", "--showlocals", "--strict-config", "--strict-markers"]
 xfail_strict = true
 testpaths = [
     "tests",

--- a/pytest_examples/divide.py
+++ b/pytest_examples/divide.py
@@ -1,4 +1,6 @@
 """Simple division function with exceptions."""
+from __future__ import annotations
+
 import sys
 
 from loguru import logger

--- a/pytest_examples/shapes.py
+++ b/pytest_examples/shapes.py
@@ -1,9 +1,11 @@
 """Summarise Shapes."""
+from typing import Any
+
 import numpy.typing as npt
 from skimage import measure
 
 
-def summarise_shape(shape: npt.NDArray) -> list:
+def summarise_shape(shape: npt.NDArray) -> list[Any]:
     """
     Summarise the region properties of a 2D numpy array using Scikit-Image.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,10 @@ from skimage import draw
 @pytest.fixture()
 def square() -> npt.NDArray:
     """Return a 2D numpy array of a square."""
-    square_array = np.zeros((6, 6), dtype=np.uint8)
-    start = (1, 1)
-    end = (5, 5)
-    rr, cc = draw.rectangle_perimeter(start, end, shape=square_array.shape)
+    square_array = np.zeros((9, 9), dtype=np.uint8)
+    start = (2, 2)
+    end = (6, 6)
+    rr, cc = draw.rectangle_perimeter(start, end)
     square_array[rr, cc] = 1
     return square_array
 

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -33,7 +33,7 @@ def test_divide(a: float | int, b: float | int, expected: float) -> None:
         pytest.param(10, [2], TypeError, id="b is list"),
     ],
 )
-def test_divide_type_errors(a: float | int, b: float | int, exception: float) -> None:
+def test_divide_type_errors(a: float | int, b: float | int, exception: TypeError) -> None:
     """Test that TypeError is raised when objects other than int or float are passed as a and b."""
     with pytest.raises(exception):
         divide(a, b)
@@ -45,7 +45,7 @@ def test_divide_type_errors(a: float | int, b: float | int, exception: float) ->
         pytest.param(10, 0, ZeroDivisionError, id="b is zero"),
     ],
 )
-def test_divide_zero_division_error(a: float | int, b: float | int, exception: float) -> None:
+def test_divide_zero_division_error(a: float | int, b: float | int, exception: ZeroDivisionError) -> None:
     """Test that ZeroDivsionError is raised when attempting to divide by zero."""
     with pytest.raises(exception):
         divide(a, b)

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -1,4 +1,6 @@
 """Example pytests showing parameterisation and testing of failures."""
+from __future__ import annotations
+
 import pytest
 
 from pytest_examples.divide import divide

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,4 +1,5 @@
 """Test the shapes module."""
+import numpy.typing as npt
 import pytest
 
 from pytest_examples.shapes import summarise_shape
@@ -12,7 +13,11 @@ from pytest_examples.shapes import summarise_shape
     ],
 )
 def test_summarise_shape_get_fixture_value(
-    shape: str, area: float, feret_diameter_max: float, centroid: tuple, request
+    shape: str,
+    area: float,
+    feret_diameter_max: float,
+    centroid: tuple[int, int],
+    request: npt.NDArray,
 ) -> None:
     """Test the summarisation of shapes."""
     shape_summary = summarise_shape(request.getfixturevalue(shape))
@@ -34,7 +39,9 @@ def test_summarise_shape_get_fixture_value(
         pytest.param(pytest.lazy_fixture("circle"), 12, 5.385164807134504, (4, 4), id="summary of circle"),
     ],
 )
-def test_summarise_shape_lazy_fixture(shape: str, area: float, feret_diameter_max: float, centroid: tuple) -> None:
+def test_summarise_shape_lazy_fixture(
+    shape: str, area: float, feret_diameter_max: float, centroid: tuple[int, int]
+) -> None:
     """Test the summarisation of shapes."""
     shape_summary = summarise_shape(shape)
     print(f"{shape_summary[0]['centroid']=}")

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -8,7 +8,7 @@ from pytest_examples.shapes import summarise_shape
 @pytest.mark.parametrize(
     ("shape", "area", "feret_diameter_max", "centroid"),
     [
-        pytest.param("square", 11, 7.810249675906654, (1.3636363636363635, 1.3636363636363635), id="summary of square"),
+        pytest.param("square", 24, 9.219544457292887, (4, 4), id="summary of square"),
         pytest.param("circle", 12, 5.385164807134504, (4, 4), id="summary of circle"),
     ],
 )
@@ -31,9 +31,9 @@ def test_summarise_shape_get_fixture_value(
     [
         pytest.param(
             pytest.lazy_fixture("square"),
-            11,
-            7.810249675906654,
-            (1.3636363636363635, 1.3636363636363635),
+            24,
+            9.219544457292887,
+            (4, 4),
             id="summary of square",
         ),
         pytest.param(pytest.lazy_fixture("circle"), 12, 5.385164807134504, (4, 4), id="summary of circle"),


### PR DESCRIPTION
Thanks @jni for higlighting I'd got types wrong which prompted me to add `mypy` to the `pre-commit` hooks suite. :+1: